### PR TITLE
Respect my decisions, dammit!

### DIFF
--- a/sofa-fries.py
+++ b/sofa-fries.py
@@ -69,7 +69,10 @@ def prompt_user(existing_file, metadata_type):
         return selection["Year"]
 
 def confirm(prompt):
-    return raw_input("%s y/[n]: " % prompt)
+    response = None
+    while response not in ["y", "n"]:
+        response = raw_input("%s y/[n]: " % prompt).lower()
+    return response == "y"
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Yes means Yes, and apparently No means Yes as well.

The confirmation function is borked, and always returns a non-empty string (always truth-y). It should instead compare your response to `y` to make sure you said yes, and re-prompt if you don't provide a valid response.
